### PR TITLE
feat: add filters.ignored_profiles config to exclude authors from reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Without extra configuration, it tries installed AI CLIs in this order:
 1. `claude`
 2. `codex`
 3. `opencode`
-4. `cursor`
+4. `cursor-agent`
 
 If no supported CLI is available, `diddo` falls back to a direct API provider when configuration and credentials are available.
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Options:
 | `ai.model` | Model for direct API; defaults: `gpt-4o-mini` (OpenAI), `claude-sonnet-4-6` (Anthropic) |
 | `ai.prompt_instructions` | Custom AI instructions (tone, language, length); period and commit list are always appended |
 | `ai.cli.prefer` | CLI/API preference: `api`, `cli`, `claude`, `codex`, `opencode`, or `cursor-agent` |
+| `filters.ignored_profiles` | List of author emails to exclude from reports. Defaults to `["test@test.com"]`. Set to `[]` to disable filtering. |
 
 Example:
 
@@ -370,6 +371,14 @@ Notes:
 - `ai.api_key` in the config file overrides environment variables
 - `ai.prompt_instructions` (optional): when set, replaces the default AI instructions (tone, language, length); period, commit count, and commit list are always appended. Use for a different language or more concise output. Empty or missing = default instructions.
 - If `ai.provider` is omitted and exactly one of `DIDDO_OPENAI_KEY` or `DIDDO_ANTHROPIC_KEY` is set, `diddo` infers the provider from that environment variable
+- `filters.ignored_profiles` excludes commits whose author email matches any entry (trimmed, case-insensitive) from summary and activity reports. `test@test.com` is ignored by default; override with a custom list or `[]` to keep everything
+
+Example:
+
+```toml
+[filters]
+ignored_profiles = ["test@test.com", "ci-bot@example.com"]
+```
 
 ## Uninstall
 

--- a/src/activity_report.rs
+++ b/src/activity_report.rs
@@ -426,9 +426,18 @@ pub fn render_markdown(report: &ActivityReport) -> String {
 }
 
 pub fn export_markdown(report: &ActivityReport) -> Result<PathBuf, std::io::Error> {
+    export_markdown_to_dir(report, Path::new("."))
+}
+
+fn export_markdown_to_dir(
+    report: &ActivityReport,
+    directory: &Path,
+) -> Result<PathBuf, std::io::Error> {
     let today = Local::now().date_naive();
-    let filename = format!("diddo_activity_{}_month_{}.md", report.period_months, today);
-    let path = unique_export_path(Path::new(&filename));
+    let path = unique_export_path(&directory.join(format!(
+        "diddo_activity_{}_month_{}.md",
+        report.period_months, today
+    )));
     let content = render_markdown(report);
     fs::write(&path, content)?;
     Ok(path)
@@ -698,8 +707,6 @@ mod tests {
     fn export_markdown_writes_file_with_correct_name_and_content() {
         let tmp = std::env::temp_dir().join(format!("diddo-export-test-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&tmp).unwrap();
 
         let date = NaiveDate::from_ymd_opt(2026, 3, 10).unwrap();
         let commits = vec![make_commit("my-repo", date, 4)];
@@ -707,7 +714,7 @@ mod tests {
         let to = NaiveDate::from_ymd_opt(2026, 3, 31).unwrap();
         let report = build_report(&commits, from, to, 1);
 
-        let path = export_markdown(&report).unwrap();
+        let path = export_markdown_to_dir(&report, &tmp).unwrap();
 
         let today = chrono::Local::now().date_naive();
         let expected_name = format!("diddo_activity_1_month_{today}.md");
@@ -717,8 +724,6 @@ mod tests {
         assert!(content.contains("# Activity Report"));
         assert!(content.contains("## Top Repositories"));
 
-        // Cleanup
-        std::env::set_current_dir(original_dir).unwrap();
         std::fs::remove_dir_all(&tmp).unwrap();
     }
 
@@ -727,8 +732,6 @@ mod tests {
         let tmp =
             std::env::temp_dir().join(format!("diddo-export-collision-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&tmp).unwrap();
 
         let date = NaiveDate::from_ymd_opt(2026, 3, 10).unwrap();
         let commits = vec![make_commit("my-repo", date, 4)];
@@ -737,10 +740,10 @@ mod tests {
         let report = build_report(&commits, from, to, 1);
 
         let today = chrono::Local::now().date_naive();
-        let first_name = format!("diddo_activity_1_month_{today}.md");
+        let first_name = tmp.join(format!("diddo_activity_1_month_{today}.md"));
         std::fs::write(&first_name, "existing").unwrap();
 
-        let path = export_markdown(&report).unwrap();
+        let path = export_markdown_to_dir(&report, &tmp).unwrap();
 
         assert_eq!(
             path.file_name().unwrap().to_str().unwrap(),
@@ -749,7 +752,6 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("# Activity Report"));
 
-        std::env::set_current_dir(original_dir).unwrap();
         std::fs::remove_dir_all(&tmp).unwrap();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,15 +25,20 @@ impl Default for UpdateConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct FiltersConfig {
+    #[serde(default = "default_ignored_profiles")]
     pub ignored_profiles: Vec<String>,
 }
 
 impl Default for FiltersConfig {
     fn default() -> Self {
         Self {
-            ignored_profiles: vec![String::from("test@test.com")],
+            ignored_profiles: default_ignored_profiles(),
         }
     }
+}
+
+fn default_ignored_profiles() -> Vec<String> {
+    vec![String::from("test@test.com")]
 }
 
 impl FiltersConfig {
@@ -566,6 +571,21 @@ ignored_profiles = ["bot@example.com", "ci@example.com"]
         );
         assert!(!config.filters.is_ignored(Some("test@test.com")));
         assert!(config.filters.is_ignored(Some("bot@example.com")));
+
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn filters_section_without_key_falls_back_to_default_list() {
+        let temp = temp_dir("filters-section-no-key");
+        let config_path = temp.join("config.toml");
+
+        fs::write(&config_path, "[filters]\n").unwrap();
+
+        let config = AppConfig::load(&config_path).unwrap();
+
+        assert_eq!(config.filters.ignored_profiles, vec!["test@test.com"]);
+        assert!(config.filters.is_ignored(Some("test@test.com")));
 
         fs::remove_dir_all(temp).unwrap();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 pub struct AppConfig {
     pub ai: AiConfig,
     pub update: UpdateConfig,
+    pub filters: FiltersConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -18,6 +19,33 @@ pub struct UpdateConfig {
 impl Default for UpdateConfig {
     fn default() -> Self {
         Self { auto_check: true }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct FiltersConfig {
+    pub ignored_profiles: Vec<String>,
+}
+
+impl Default for FiltersConfig {
+    fn default() -> Self {
+        Self {
+            ignored_profiles: vec![String::from("test@test.com")],
+        }
+    }
+}
+
+impl FiltersConfig {
+    pub fn is_ignored(&self, email: Option<&str>) -> bool {
+        let Some(candidate) = email.map(str::trim).filter(|s| !s.is_empty()) else {
+            return false;
+        };
+        self.ignored_profiles
+            .iter()
+            .map(|entry| entry.trim())
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| entry.eq_ignore_ascii_case(candidate))
     }
 }
 
@@ -502,5 +530,77 @@ prompt_instructions = "  \n\t "
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
         ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn filters_default_contains_test_profile() {
+        let temp = temp_dir("filters-default");
+        let missing = temp.join("config.toml");
+
+        let config = AppConfig::load(&missing).unwrap();
+
+        assert_eq!(config.filters.ignored_profiles, vec!["test@test.com"]);
+        assert!(config.filters.is_ignored(Some("test@test.com")));
+
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn filters_user_list_replaces_defaults() {
+        let temp = temp_dir("filters-override");
+        let config_path = temp.join("config.toml");
+
+        fs::write(
+            &config_path,
+            r#"[filters]
+ignored_profiles = ["bot@example.com", "ci@example.com"]
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load(&config_path).unwrap();
+
+        assert_eq!(
+            config.filters.ignored_profiles,
+            vec!["bot@example.com", "ci@example.com"]
+        );
+        assert!(!config.filters.is_ignored(Some("test@test.com")));
+        assert!(config.filters.is_ignored(Some("bot@example.com")));
+
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn filters_empty_list_disables_filtering() {
+        let temp = temp_dir("filters-empty");
+        let config_path = temp.join("config.toml");
+
+        fs::write(
+            &config_path,
+            r#"[filters]
+ignored_profiles = []
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load(&config_path).unwrap();
+
+        assert!(config.filters.ignored_profiles.is_empty());
+        assert!(!config.filters.is_ignored(Some("test@test.com")));
+
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn filters_is_ignored_trims_and_ignores_case() {
+        let filters = super::FiltersConfig {
+            ignored_profiles: vec![String::from("  Test@Test.COM  ")],
+        };
+
+        assert!(filters.is_ignored(Some("test@test.com")));
+        assert!(filters.is_ignored(Some("  TEST@test.com")));
+        assert!(!filters.is_ignored(Some("other@test.com")));
+        assert!(!filters.is_ignored(None));
+        assert!(!filters.is_ignored(Some("   ")));
     }
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::activity_report::{self, ActivityReport, PERIOD_OPTIONS};
+use crate::config::AppConfig;
 use crate::db::Database;
 use crate::{RANGE_DATE_FORMATS, parse_supported_date, range_date_format_error};
 use chrono::{Local, NaiveDate};
@@ -168,7 +169,10 @@ fn restore_terminal(stdout: &mut impl Write) {
     let _ = terminal::disable_raw_mode();
 }
 
-pub fn run(db_path: Option<&Path>) -> Result<Option<String>, Box<dyn std::error::Error>> {
+pub fn run(
+    db_path: Option<&Path>,
+    config_path: Option<&Path>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
     terminal::enable_raw_mode()?;
 
     let prev_hook = std::panic::take_hook();
@@ -179,7 +183,7 @@ pub fn run(db_path: Option<&Path>) -> Result<Option<String>, Box<dyn std::error:
         (*prev_hook_rc)(info);
     }));
 
-    let result = run_inner(db_path);
+    let result = run_inner(db_path, config_path);
 
     let _ = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| (*prev_hook_restore)(info)));
@@ -190,7 +194,10 @@ pub fn run(db_path: Option<&Path>) -> Result<Option<String>, Box<dyn std::error:
     result
 }
 
-fn run_inner(db_path: Option<&Path>) -> Result<Option<String>, Box<dyn std::error::Error>> {
+fn run_inner(
+    db_path: Option<&Path>,
+    config_path: Option<&Path>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
     let mut stdout = io::stdout();
     let mut state = UiState::Menu { selected: 0 };
 
@@ -259,7 +266,7 @@ fn run_inner(db_path: Option<&Path>) -> Result<Option<String>, Box<dyn std::erro
                     match action {
                         Action::Select => {
                             let (months, _) = PERIOD_OPTIONS[*selected];
-                            match build_activity_report(db_path, months) {
+                            match build_activity_report(db_path, config_path, months) {
                                 Ok(report) => {
                                     let report_text = activity_report::render_terminal(&report);
                                     state = UiState::ActivityReportView {
@@ -384,13 +391,22 @@ fn activity_menu_index() -> usize {
 
 fn build_activity_report(
     db_path: Option<&Path>,
+    config_path: Option<&Path>,
     months: u32,
 ) -> Result<ActivityReport, Box<dyn std::error::Error>> {
     let path = db_path.ok_or("Database path not available")?;
     let database = Database::open(path)?;
     let today = Local::now().date_naive();
     let (from, to) = activity_report::compute_period_range(months, today);
-    let commits = database.query_date_range(from, to)?;
+    let mut commits = database.query_date_range(from, to)?;
+    let filters = config_path
+        .map(AppConfig::load)
+        .transpose()
+        .ok()
+        .flatten()
+        .map(|config| config.filters)
+        .unwrap_or_default();
+    commits.retain(|c| !filters.is_ignored(c.author_email.as_deref()));
     Ok(activity_report::build_report(&commits, from, to, months))
 }
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::activity_report::{self, ActivityReport, PERIOD_OPTIONS};
-use crate::config::AppConfig;
+use crate::config::{AppConfig, FiltersConfig};
 use crate::db::Database;
 use crate::{RANGE_DATE_FORMATS, parse_supported_date, range_date_format_error};
 use chrono::{Local, NaiveDate};
@@ -173,6 +173,8 @@ pub fn run(
     db_path: Option<&Path>,
     config_path: Option<&Path>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let filters = load_filters(config_path);
+
     terminal::enable_raw_mode()?;
 
     let prev_hook = std::panic::take_hook();
@@ -183,7 +185,7 @@ pub fn run(
         (*prev_hook_rc)(info);
     }));
 
-    let result = run_inner(db_path, config_path);
+    let result = run_inner(db_path, &filters);
 
     let _ = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| (*prev_hook_restore)(info)));
@@ -194,9 +196,25 @@ pub fn run(
     result
 }
 
+fn load_filters(config_path: Option<&Path>) -> FiltersConfig {
+    let Some(path) = config_path else {
+        return FiltersConfig::default();
+    };
+    match AppConfig::load(path) {
+        Ok(config) => config.filters,
+        Err(error) => {
+            eprintln!(
+                "warning: failed to load config from {}: {error}. Using default filters.",
+                path.display()
+            );
+            FiltersConfig::default()
+        }
+    }
+}
+
 fn run_inner(
     db_path: Option<&Path>,
-    config_path: Option<&Path>,
+    filters: &FiltersConfig,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     let mut stdout = io::stdout();
     let mut state = UiState::Menu { selected: 0 };
@@ -266,7 +284,7 @@ fn run_inner(
                     match action {
                         Action::Select => {
                             let (months, _) = PERIOD_OPTIONS[*selected];
-                            match build_activity_report(db_path, config_path, months) {
+                            match build_activity_report(db_path, filters, months) {
                                 Ok(report) => {
                                     let report_text = activity_report::render_terminal(&report);
                                     state = UiState::ActivityReportView {
@@ -391,7 +409,7 @@ fn activity_menu_index() -> usize {
 
 fn build_activity_report(
     db_path: Option<&Path>,
-    config_path: Option<&Path>,
+    filters: &FiltersConfig,
     months: u32,
 ) -> Result<ActivityReport, Box<dyn std::error::Error>> {
     let path = db_path.ok_or("Database path not available")?;
@@ -399,13 +417,6 @@ fn build_activity_report(
     let today = Local::now().date_naive();
     let (from, to) = activity_report::compute_period_range(months, today);
     let mut commits = database.query_date_range(from, to)?;
-    let filters = config_path
-        .map(AppConfig::load)
-        .transpose()
-        .ok()
-        .flatten()
-        .map(|config| config.filters)
-        .unwrap_or_default();
     commits.retain(|c| !filters.is_ignored(c.author_email.as_deref()));
     Ok(activity_report::build_report(&commits, from, to, months))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,8 +502,7 @@ fn run_summary_command(cli: ParsedCli) -> Result<(), Box<dyn Error>> {
     let window = resolve_summary_window(selection, today)?;
     let app_config = config::AppConfig::load(&paths.config_path)?;
     let mut commits = load_commits_for_window(&database, &window)?;
-    let filters = app_config.filters.clone();
-    commits.retain(|c| !filters.is_ignored(c.author_email.as_deref()));
+    commits.retain(|c| !app_config.filters.is_ignored(c.author_email.as_deref()));
     let rendered = render_summary_output(
         &database,
         summary_args,

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,8 +263,10 @@ fn main() {
         });
 
     if is_bare_invocation && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
-        let db_path = paths::AppPaths::new().ok().map(|p| p.db_path);
-        let selected = match interactive::run(db_path.as_deref()) {
+        let resolved_paths = paths::AppPaths::new().ok();
+        let db_path = resolved_paths.as_ref().map(|p| p.db_path.clone());
+        let config_path = resolved_paths.as_ref().map(|p| p.config_path.clone());
+        let selected = match interactive::run(db_path.as_deref(), config_path.as_deref()) {
             Ok(Some(command)) => command,
             Ok(None) => return,
             Err(error) => {
@@ -498,13 +500,16 @@ fn run_summary_command(cli: ParsedCli) -> Result<(), Box<dyn Error>> {
     let database = db::Database::open(&paths.db_path)?;
     let today = Local::now().date_naive();
     let window = resolve_summary_window(selection, today)?;
-    let commits = load_commits_for_window(&database, &window)?;
+    let app_config = config::AppConfig::load(&paths.config_path)?;
+    let mut commits = load_commits_for_window(&database, &window)?;
+    let filters = app_config.filters.clone();
+    commits.retain(|c| !filters.is_ignored(c.author_email.as_deref()));
     let rendered = render_summary_output(
         &database,
         summary_args,
         window,
         commits,
-        || Ok(config::AppConfig::load(&paths.config_path)?),
+        move || Ok(app_config),
         ai::create_provider,
     )?;
 
@@ -2130,6 +2135,7 @@ mod tests {
                 },
             },
             update: crate::config::UpdateConfig { auto_check: false },
+            filters: crate::config::FiltersConfig::default(),
         };
 
         let output = format_metadata(&database, 0, &status, &config).unwrap();


### PR DESCRIPTION
## Summary

- Adds a new `[filters]` config section with `ignored_profiles: Vec<String>` that excludes matching author emails from summary output, global stats, and the activity report (both CLI and interactive TUI).
- Default list seeds `["test@test.com"]` so scaffolding from integration-test runs (the `.tmp*` repos that show up under `test@test.com` on `diddo week`) no longer pollutes real reports. Users can override with their own list or set `ignored_profiles = []` to disable.
- Matching is trimmed and case-insensitive. Config is loaded once up front in `run_summary_command` and threaded into `interactive::run` / `build_activity_report`.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -- --test-threads=1` — all 226 tests pass
- [x] 4 new unit tests in `config::tests`: default contains `test@test.com`, user list replaces defaults, empty list disables filtering, `is_ignored` trims + ignores case
- [ ] Manual: run `diddo week` on a workspace where test scaffolding committed to `.tmp*` repos under `test@test.com` and confirm that profile no longer appears in the report

## Notes

- Pre-existing flakiness in `activity_report::tests::export_markdown_*` (concurrent `std::env::set_current_dir`) reproduces on `main` and is unrelated to this change. Single-threaded run is clean.